### PR TITLE
Add random bytes functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # base64-url
 
-Base64 encode, decode, escape and unescape for URL applications.
+Base64 encode, decode, escape, unescape and random generator for URL applications.
 
 <a href="https://nodei.co/npm/base64-url/"><img src="https://nodei.co/npm/base64-url.png?downloads=true"></a>
 
@@ -21,6 +21,13 @@ Base64 encode, decode, escape and unescape for URL applications.
     > base64url.unescape('This-is_goingto-escape');
     This+is/goingto+escape==
   	
+    > base64url.pseudoRandomBytes(15, function(err, bytes) {
+      // bytes contains encoded pseudorandom bytes
+    });
+
+    > base64url.randomBytes(15, function(err, bytes) {
+      // bytes contains encoded cryptographic random bytes
+    });
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var crypto = require('crypto');
 var base64url = module.exports;
 
 base64url.unescape = function unescape (str) {
@@ -21,4 +22,30 @@ base64url.encode = function encode (str) {
 
 base64url.decode = function decode (str) {
   return new Buffer(this.unescape(str), 'base64').toString();
+};
+
+base64url.pseudoRandomBytes = function pseudoRandomBytes (size, callback) {
+  if (!callback) {
+    return base64url.encode(crypto.pseudoRandomBytes(size));
+  }
+
+  crypto.pseudoRandomBytes(size, function(err, buffer) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, base64url.encode(buffer));
+  });
+};
+
+base64url.randomBytes = function randomBytes (size, callback) {
+  if (!callback) {
+    return base64url.encode(crypto.randomBytes(size));
+  }
+
+  crypto.randomBytes(size, function(err, buffer) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, base64url.encode(buffer));
+  });
 };

--- a/test.js
+++ b/test.js
@@ -1,10 +1,11 @@
 'use strict';
 
+var crypto = require('crypto');
 var tape = require('tape');
 var base64url = require('./index');
 
 tape('base64', function(assert) {
-  assert.plan(4);
+  assert.plan(18);
 
   var text = 'Node.js is awesome.';
 
@@ -24,4 +25,32 @@ tape('base64', function(assert) {
   assert.equal(unescape.match(/\-|_/g),
     null,
     'unescape (back to first form): ' + unescape);
+
+  ['pseudoRandomBytes', 'randomBytes'].forEach(function(fun) {
+    crypto[fun] = function(size) {
+      assert.equal(size, 3);
+      return new Buffer('112233', 'hex');
+    };
+    var randomBytes = base64url[fun](3);
+    assert.equal(randomBytes, 'ESIz', 'sync randomBytes: ' + randomBytes);
+
+    crypto[fun] = function(size, callback) {
+      assert.equal(size, 4);
+      callback(new Error('error'));
+    };
+
+    base64url[fun](4, function(err) {
+      assert.equal(err.message, 'error', 'randomBytes error: ' + err.message);
+    });
+
+    crypto[fun] = function(size, callback) {
+      assert.equal(size, 6);
+      callback(null, new Buffer('112233445566', 'hex'));
+    };
+
+    base64url[fun](6, function(err, randomBytes) {
+      assert.equal(err, null, 'async randomBytes error: ' + err);
+      assert.equal(randomBytes, 'ESIzRFVm', 'randomBytes: ' + randomBytes);
+    });
+  });
 });


### PR DESCRIPTION
Often applications just need some random data (e.g. for OAuth2 tokens). Providing this functions directly in the ```base64-url``` package would make the other code more readable and avoids code duplication. Creating an additional npm package only for the random generator feels a little bit overkill to me, since it does not introduce any new external dependencies.