### PR TITLE
make it es5 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict'
 
 module.exports = {
-  unescape,
-  escape,
-  encode,
-  decode
+  unescape: unescape,
+  escape: escape,
+  encode: encode,
+  decode: decode
 }
 
 function unescape (str) {


### PR DESCRIPTION
can not minified by create-react-app, make it es5 compatible.

> Some third-party packages don't compile their code to ES5 before publishing to npm. This often causes problems in the ecosystem because neither browsers (except for most modern versions) nor some tools currently support all ES6 features. We recommend to publish code on npm as ES5 at least for a few more years.

[npm run build fails to minify](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify)